### PR TITLE
Fixed bug on Firefox where profile wouldn't update

### DIFF
--- a/client/src/methods/user.js
+++ b/client/src/methods/user.js
@@ -41,6 +41,7 @@ async function updateUser(user) {
     },
     body: JSON.stringify(user)
   })
+  .then(response => window.location.reload())
   .catch(error => {
     console.log(response);  // fix TypeError even when fetch is successful
     window.alert(error);    // I think it works by forcing await to work, maybe

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -95,7 +95,6 @@ function Profile(props) {
       description: (description === null)? user.description: description
     }
     updateUser(newUser);
-    navigate(0);  // reload page (to display update)
   }
 
   return (


### PR DESCRIPTION
TL;DR since I've goofed this commit 3 times lol: window
refreshes work best in async fetch catches
(the .then() clause), so that the webpage will refresh
*only* after the fetch has succeeded; if put on the Page
level, the refresh could occur before the fetch succeeds,
causing a networkError where the fetch doesn't get routed.
(see user.js line 44 of this commit :) )