### PR TITLE
jordan: fix proxy issue for local

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "canvas": "^2.9.0",
         "file-saver": "^2.0.5",
+        "http-proxy-middleware": "^2.0.3",
         "react": "^17.0.2",
         "react-cookie": "^4.1.1",
         "react-dom": "^17.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "canvas": "^2.9.0",
     "file-saver": "^2.0.5",
+    "http-proxy-middleware": "^2.0.3",
     "react": "^17.0.2",
     "react-cookie": "^4.1.1",
     "react-dom": "^17.0.2",
@@ -39,6 +40,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "proxy": "http://localhost:5000"
+  }
 }

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  app.use(
+    '/db', 
+    createProxyMiddleware({
+      target: 'http://localhost:5000',
+      changeOrigin: true
+    })
+  );
+};


### PR DESCRIPTION
Instead of just adding "proxy": "http://localhost:5000" in package.json
of client (which does not work, known issue apparently), use a
workaround http-proxy-middleware (new npm package, ugh).

From https://stackoverflow.com/a/70413065