### PR TITLE
jordan: make minimum scaling smaller

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -4,7 +4,7 @@
 
 :root {
   /* sizes */
-  --scale: min(max(min(1vw, 1vh), 7.2px), 10.8px);
+  --scale: min(max(min(1vw, 1vh), 3.6px), 10.8px);
   --page-width: min(calc(90 * var(--scale)), 90vw);
   
   /* map dimension */


### PR DESCRIPTION
Minimum scale variable was 7.2px and is now 3.6px (better phone
compatibility).