### PR TITLE
jordan: fix save bug with map download

### DIFF
--- a/client/src/pages/Creator.js
+++ b/client/src/pages/Creator.js
@@ -268,10 +268,10 @@ function Creator() {
       assets: assets,
       characters: characters
     };
-    let FileSaver = require('file-saver');
+    let fileSaver = require("file-saver");
     let file = await downloadMap(mapInfo);
-    FileSaver.saveAs(file);
-    handleMapSave();
+    fileSaver.saveAs(file);
+    if (author === username) handleMapSave();
   }
 
   return (


### PR DESCRIPTION
Fix the bug that map download from non-author changes actually saves to
the map. It was merely a forgotten if statement.